### PR TITLE
Fix error when using from cli

### DIFF
--- a/ocspchecker/__main__.py
+++ b/ocspchecker/__main__.py
@@ -25,9 +25,9 @@ arg_parser.add_argument(
     "--port",
     "-p",
     metavar="port",
-    type=str,
+    type=int,
     required=False,
-    default="443",
+    default=443,
     help="The port to test (default is 443)",
 )
 


### PR DESCRIPTION
# Purpose
ocspchecker as cli tools failes because arg_port is expected to be a int instead of str

# Does this introduce a breaking change?
- [ ] Yes
- [x] No

# Pull Request Type

What kind of change does this Pull Request introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

# How Has This Been Tested?

using ocspchecker on cli works again
