### PR TITLE
allow to provide path to ca-certs from outside

### DIFF
--- a/ocspchecker/ocspchecker.py
+++ b/ocspchecker/ocspchecker.py
@@ -7,7 +7,7 @@
 from socket import gaierror, timeout, socket, SOCK_STREAM, AF_INET
 from urllib.parse import urlparse
 from urllib import request, error
-from typing import List, Tuple, Union, Optional
+from typing import List, Tuple, Union
 from pathlib import Path
 
 from nassl.ssl_client import (
@@ -103,7 +103,7 @@ def get_ocsp_status(host: str, port: int = 443, proxy: Union[None, Tuple[str, in
     return results
 
 
-def get_certificate_chain(host: str, port: int = 443, proxy: Union[None, Tuple[str, int]] = None, request_timeout: float = 3.0, path_to_ca_certs: Optional[Path] = Path(certifi.where())) -> List[str]:
+def get_certificate_chain(host: str, port: int = 443, proxy: Union[None, Tuple[str, int]] = None, request_timeout: float = 3.0, path_to_ca_certs: Path = Path(certifi.where())) -> List[str]:
     """Connect to the host on the port and obtain certificate chain"""
 
     func_name: str = "get_certificate_chain"

--- a/ocspchecker/ocspchecker.py
+++ b/ocspchecker/ocspchecker.py
@@ -7,7 +7,7 @@
 from socket import gaierror, timeout, socket, SOCK_STREAM, AF_INET
 from urllib.parse import urlparse
 from urllib import request, error
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 from pathlib import Path
 
 from nassl.ssl_client import (
@@ -36,9 +36,6 @@ class InitialConnectionError(Exception):
 class OcspResponderError(Exception):
     """Custom exception class to identify errors obtaining a response from a CA'a Responder"""
 
-
-# Get the local path to the ca certs
-path_to_ca_certs = Path(certifi.where())
 
 openssl_errors: dict = {
     # https://github.com/openssl/openssl/issues/6805
@@ -106,7 +103,7 @@ def get_ocsp_status(host: str, port: int = 443, proxy: Union[None, Tuple[str, in
     return results
 
 
-def get_certificate_chain(host: str, port: int = 443, proxy: Union[None, Tuple[str, int]] = None, request_timeout: float = 3.0) -> List[str]:
+def get_certificate_chain(host: str, port: int = 443, proxy: Union[None, Tuple[str, int]] = None, request_timeout: float = 3.0, path_to_ca_certs: Optional[Path] = Path(certifi.where())) -> List[str]:
     """Connect to the host on the port and obtain certificate chain"""
 
     func_name: str = "get_certificate_chain"


### PR DESCRIPTION
# Purpose
Allow to provide the local path to trusted ca-certs, so any user can add/update it's ca without requiring certify to generate new release.

# Does this introduce a breaking change?
- [ ] Yes
- [x] No

# Pull Request Type

What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

# How Has This Been Tested?
I tested this locally pointing to `/etc/ssl/certs/ca-certificates.crt`.  
Some of the package tests were already broken, this change didn't seem to break any new one, since by default the used cert will still be the ones provided by certify.
